### PR TITLE
fix: rimosso Codeberg dalla lista delle piattaforme

### DIFF
--- a/per-chi-amministra-nel-pubblico/rilasciare-nuovo-software-libero.rst
+++ b/per-chi-amministra-nel-pubblico/rilasciare-nuovo-software-libero.rst
@@ -24,8 +24,6 @@ progetti liberi moderni:
 
 -  Bitbucket - `https://bitbucket.org <https://bitbucket.org/>`__
 
--  Codeberg - https://codeberg.org/
-
 All’interno di uno strumento di code hosting è possibile organizzare i
 propri progetti in modo gerarchico, creando un’\ **organizzazione** che
 conterrà all’interno tutti i singoli **repository** di software. Tale


### PR DESCRIPTION
Non c'è supporto per Codeberg nel backend del Catalogo, per ora. Rimosso dai suggerimenti delle possibili piattaforme.